### PR TITLE
Adds admin user

### DIFF
--- a/lib/bet_your_balls/core/user.ex
+++ b/lib/bet_your_balls/core/user.ex
@@ -7,6 +7,7 @@ defmodule BetYourBalls.Core.User do
   schema "core_users" do
     field :email, :string
     field :username, :string
+    field :admin, :boolean
 
     has_many :bets, BetYourBalls.Core.Bet
 

--- a/lib/bet_your_balls/plugs/ensure_admin.ex
+++ b/lib/bet_your_balls/plugs/ensure_admin.ex
@@ -1,0 +1,29 @@
+defmodule BetYourBalls.Plugs.EnsureAdmin do
+  @behaviour Plug
+
+  import Plug.Conn
+  import Phoenix.Controller
+
+  def init(default), do: default
+
+  def call(%{assigns: %{current_user: current_user}} = conn, _) do
+    if current_user.admin do
+      conn
+    else
+      conn
+        |> flash_and_redirect
+    end
+  end
+
+  def call(conn, _) do
+    conn
+      |> flash_and_redirect
+  end
+
+  defp flash_and_redirect(conn) do
+    conn
+      |> put_flash(:error, "You do not have the proper authorization to do that")
+      |> redirect(to: "/")
+      |> halt
+  end
+end

--- a/lib/bet_your_balls_web/templates/match/index.html.pug
+++ b/lib/bet_your_balls_web/templates/match/index.html.pug
@@ -5,16 +5,18 @@ table.table.table-striped
       td Game
       td Status
       td Actions
-    
+
   tbody
-    = for match <- @matches do 
+    = for match <- @matches do
       tr
         td= match.title
         td= match.game_name
         td= match.status
         td
           = link "Show", to: match_path(@conn, :show, match), class: "btn btn-xs btn-primary"
-          = link "Edit", to: match_path(@conn, :edit, match), class: "btn btn-xs btn-warning"
-            
-= link(to: match_path(@conn, :new), class: "btn btn-primary") do
-  span Create a Match
+          = if @current_user.admin do
+            = link "Edit", to: match_path(@conn, :edit, match), class: "btn btn-xs btn-warning"
+
+= if @current_user.admin do
+  = link(to: match_path(@conn, :new), class: "btn btn-primary") do
+    span Create a Match

--- a/priv/repo/migrations/20171205112821_adds_admin_to_users.exs
+++ b/priv/repo/migrations/20171205112821_adds_admin_to_users.exs
@@ -1,0 +1,9 @@
+defmodule BetYourBalls.Repo.Migrations.AddAdminToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:core_users) do
+      add :admin, :boolean, default: false
+    end
+  end
+end


### PR DESCRIPTION
- [x] Adds boolean `admin` field to `users`
- [x] Creates `EnsureAdmin` plug to restrict access for non admin users
- [x] Shows only non pending matches for non admin users
- [x] Restrict matches controller actions for non admin users except for `index` and `show`
- [x] Hide `Create match` and `Edit` match button for non admin users

NOTE: No way to create an admin user except through the console